### PR TITLE
New deployer plugin

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
@@ -21,7 +22,8 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - name: Build with Gradle
-        run: ./gradlew build
+      - name: Build and test
+        run: |
+          chmod +x gradlew
+          ./gradlew build
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,12 @@
 # Publish to Maven Central
-#
-# Instructions from https://gist.github.com/sualeh/ae78dc16123899d7942bc38baba5203c
 
 name: publish
 
 on:
   repository_dispatch:
     types: manual-publish
-#  release:
-#    types: [created]
+  release:
+    types: [created]
 
 jobs:
   publish:
@@ -16,18 +14,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - id: install-secret-key
-        name: Install gpg secret key
-        run: cat <(echo -e "${{ secrets.SEER_GPG_SECRET_KEY }}") | gpg --batch --import
       - name: Publish
-        run: ./gradlew uploadArchives closeAndReleaseRepository -Psigning.keyId=${{ secrets.SEER_GPG_KEYID }} -Psigning.password=${{ secrets.SEER_GPG_PASSWORD }} -Psigning.secretKeyRingFile=${{ secrets.SEER_GPG_KEYRING_FILE }}
+        run: |
+          chmod +x gradlew
+          ./gradlew publish closeAndReleaseRepository
         env:
           ORG_GRADLE_PROJECT_nexusUsername: ${{ secrets.NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SEER_GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SEER_GPG_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,8 @@ plugins {
     id 'java-library'
     id 'checkstyle'
     id "com.github.spotbugs" version "4.2.1"
-    id 'com.bmuschko.nexus' version '2.3.1'          // prepares and copies artifacts to Sonotype OSS
+    id 'maven-publish'
+    id 'signing'
     id "io.codearte.nexus-staging" version "0.21.2"  // logs into Sonotype OSS and does a "Close" and "Release"
     id 'com.adarshr.test-logger' version '2.0.0'
     id "com.github.ben-manes.versions" version "0.28.0"
@@ -20,6 +21,9 @@ tasks.withType(JavaCompile) {
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
+
+    withJavadocJar()
+    withSourcesJar()
 }
 
 repositories {
@@ -48,10 +52,6 @@ jar {
     }
 }
 
-testlogger {
-    theme 'mocha'
-}
-
 checkstyle {
     configFile = file('config/checkstyle/checkstyle.xml')
 }
@@ -62,45 +62,89 @@ spotbugs {
 }
 
 // don't try to release a snapshot to a non-snapshot repository, that won't work anyway
-if (version.endsWith('-SNAPSHOT'))
+if (version.endsWith('-SNAPSHOT')) {
+    gradle.startParameter.excludedTaskNames += 'signMavenJavaPublication'
     gradle.startParameter.excludedTaskNames += 'closeAndReleaseRepository'
+}
 
-modifyPom {
-    project {
-        name 'X12 Parser'
-        description 'A Java library for parsing X12 files, including ANSI 837'
-        url 'https://github.com/imsweb/x12-parser'
-        inceptionYear '2015'
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = 'x12-parser'
+            from components.java
+            versionMapping {
+                usage('java-api') {
+                    fromResolutionOf('runtimeClasspath')
+                }
+                usage('java-runtime') {
+                    fromResolutionResult()
+                }
+            }
+            pom {
+                name = 'X12 Parser'
+                description = 'A Java library for parsing X12 files, including ANSI 837'
+                url = 'https://github.com/imsweb/x12-parser'
+                inceptionYear = '2015'
 
-        scm {
-            url 'https://github.com/imsweb/x12-parser'
-            connection 'scm:https://github.com/imsweb/x12-parser.git'
-            developerConnection 'scm:git@github.com:imsweb/x12-parser.git'
-        }
+                licenses {
+                    license {
+                        name = 'A modified BSD License (BSD)'
+                        url = 'https://github.com/imsweb/x12-parser/blob/master/LICENSE'
+                        distribution = 'repo'
+                    }
+                }
 
-        licenses {
-            license {
-                name 'A modified BSD License (BSD)'
-                url 'https://github.com/imsweb/x12-parser/blob/master/LICENSE'
-                distribution 'repo'
+                developers {
+                    developer {
+                        id = 'AngelaszekD'
+                        name = 'David Angelaszek'
+                        email = 'AngelaszekD@imsweb.com'
+                    }
+                    developer {
+                        id = 'ctmay4'
+                        name = 'Chuck May'
+                        email = 'mayc@imsweb.com'
+                    }
+                }
+
+                scm {
+                    url = 'https://github.com/imsweb/x12-parser'
+                    connection = 'scm:https://github.com/imsweb/x12-parser.git'
+                    developerConnection = 'scm:git@github.com:imsweb/x12-parser.git'
+                }
             }
         }
+    }
+    repositories {
+        maven {
+            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
-        developers {
-            developer {
-                id 'AngelaszekD'
-                name 'David Angelaszek'
-                email 'AngelaszekD@imsweb.com'
-            }
-            developer {
-                id 'ctmay4'
-                name 'Chuck May'
-                email 'mayc@imsweb.com'
+            credentials {
+                username = project.findProperty('nexusUsername') ?: ''
+                password = project.findProperty('nexusPassword') ?: ''
             }
         }
     }
 }
 
+signing {
+    def signingKey = project.findProperty('signingKey') ?: ''
+    def signingPassword = project.findProperty('signingPassword') ?: ''
+
+    useInMemoryPgpKeys(signingKey, signingPassword)
+
+    sign publishing.publications.mavenJava
+}
+
+javadoc {
+    if (JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
+    }
+}
+
+// configure nexus staging plugin
 nexusStaging {
     numberOfRetries = 50
     delayBetweenRetriesInMillis = 5000

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ repositories {
 }
 
 dependencies {
+    spotbugs 'com.github.spotbugs:spotbugs:4.0.3'
+
     api 'com.thoughtworks.xstream:xstream:1.4.12'
 
     testImplementation 'junit:junit:4.13'
@@ -57,7 +59,6 @@ checkstyle {
 }
 
 spotbugs {
-    toolVersion = '4.0.3'
     excludeFilter = file('config/spotbugs/spotbugs-exclude.xml')
 }
 


### PR DESCRIPTION
We are using [gradle-nexus-plugin](https://github.com/bmuschko/gradle-nexus-plugin) to handle our releases to Maven Central.  It uses features that are scheduled to be removed in Gradle 7.0.  The maintainer stated he was not going to fix this.  

https://github.com/bmuschko/gradle-nexus-plugin/issues/76

This requests switches to using the standard `maven-publish` plugin.